### PR TITLE
Improve Deep Learning EE Eval App

### DIFF
--- a/apps/eval_vlne.cxx
+++ b/apps/eval_vlne.cxx
@@ -1,3 +1,8 @@
+/*
+ * An application to evaluate the Deep Learning energy estimator,
+ * that is using Particle Flow information.
+ */
+
 #include "config.h"
 #if (HAVE_VLNEVAL_INC == 1) && (HAVE_VLNEVAL_LIB == 1)
 
@@ -239,7 +244,7 @@ Config parseArgs(int argc, char** argv)
         ("help,h", "print this help message")
         (
             "branch,b",
-            po::value<std::string>()->default_value("dlee"),
+            po::value<std::string>()->default_value("vlne"),
             "branch to save energy"
         )
         (

--- a/apps/eval_vlne.cxx
+++ b/apps/eval_vlne.cxx
@@ -296,12 +296,13 @@ Config parseArgs(int argc, char** argv)
             .run(),
         vm
     );
-    po::notify(vm);
 
     if (vm.count("help")) {
         usage(argv[0], options);
         exit(0);
     }
+
+    po::notify(vm);
 
     if (vm.count("input") == 0) {
         usage(argv[0], options);


### PR DESCRIPTION
Hi everyone (@HaiwangYu),

I am submitting a small PR that improves the Deep Learning EE. This PR implements the following:
1. Fixes printing of the help message when the `--model` argument is missing (previously it resulted in a silent segfault)
2. Implements support of Full/Partial Containment selection.
3. Renames application `eval_dlee` to `eval_vlne`. This renaming is performed since it was suggested that the DLEE name clashes with a name of some MicroBooNE analysis. `vlne` stands for Variable Length (Array) Network Energy.