### PR TITLE
Fix DL EE evaluation when uboone files contain NaN values

### DIFF
--- a/apps/eval_vlne.cxx
+++ b/apps/eval_vlne.cxx
@@ -301,8 +301,8 @@ Config parseArgs(int argc, char** argv)
             po::value<std::string>()->default_value("numu"),
             "flavor of inputs [numu|nue]"
         )
-        ("input,i",  po::value<std::string>(), "Input File")
-        ("model,m",  po::value<std::string>()->required(), "Model Directory")
+        ("input,i",  po::value<std::string>(), "input file")
+        ("model,m",  po::value<std::string>()->required(), "model directory")
         ;
 
     po::positional_options_description positional_args;

--- a/apps/eval_vlne.cxx
+++ b/apps/eval_vlne.cxx
@@ -503,18 +503,21 @@ void processFile(TFile &file, const Config &config, VLN::VLNEnergyModel &model)
 
 int main(int argc, char** argv)
 {
-    std::cout << "Starting..." << std::endl;
-
     const Config config = parseArgs(argc, argv);
     TFile file(config.input.c_str(), "update");
 
     VLN::VLNEnergyModel model(config.model);
 
-    std::cout << "Evaluating energy for file " << config.input << std::endl;
+    std::cout
+        << "Starting energy evaluation"             << std::endl
+        << "  - File: "         << config.input     << std::endl
+        << "  - Model: "        << config.model     << std::endl
+        << "  - Save Branch: "  << config.branch    << std::endl;
+
     processFile(file, config, model);
     file.Write();
 
-    std::cout << "Done" << std::endl;
+    std::cout << "Finished energy evaluation" << std::endl;
 }
 
 #else  /* HAVE_VLNEVAL != 1 */


### PR DESCRIPTION
Hello everyone,

This PR is hopefully the last fix to the `eval_vlne.cxx`, responsible for the DL EE evaluation. This PR introduces the following changes:
1. Masks NaN values by 0's before feeding them to the DL EE (nue score is the biggest NaN offender).
2. Improves progress indicator.
3. Improves help/info messages.